### PR TITLE
Remove unnecessary 'detach' for  items returned AsNoTracking()

### DIFF
--- a/Chapter10/Catalog/src/Catalog.Infrastructure/Repositories/ItemRepository.cs
+++ b/Chapter10/Catalog/src/Catalog.Infrastructure/Repositories/ItemRepository.cs
@@ -35,9 +35,6 @@ namespace Catalog.Infrastructure.Repositories
                 .Include(x => x.Genre)
                 .Include(x => x.Artist).FirstOrDefaultAsync();
 
-            if (item == null) return null;
-
-            _context.Entry(item).State = EntityState.Detached;
             return item;
         }
 


### PR DESCRIPTION
I believe the items are already detached due to use of AsNoTacking() (this is the case in the printed copy of my book) so the use of _context.Entry(item).State = EntityState.Detached; is therefore unnecessary.